### PR TITLE
Correct the num of pages when total_posts exactly equals to per_page

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -607,8 +607,9 @@ func renderPaginator(pgCnf Mapper, layouts map[string]Mapper, topCtx mustache.Co
 	current_page_number := 0
 	log.Println("Total posts: ", len(chronological))
 	for i, post_id := range chronological {
-		current_page_number = (i / per_page) + 1
 		if i != 0 && i%per_page == 0 {
+			current_page_number++
+			log.Printf("rendering page #%d with %d posts", current_page_number, len(one_page))
 			posts_ctx["current_page_number"] = current_page_number
 			posts_ctx["paginator"] = one_page
 			if current_page_number >= 2 {
@@ -624,6 +625,8 @@ func renderPaginator(pgCnf Mapper, layouts map[string]Mapper, topCtx mustache.Co
 		one_page = append(one_page, post)
 	}
 	if len(one_page) > 0 {
+		current_page_number++
+		log.Printf("rendering page #%d with %d post(s)", current_page_number, len(one_page))
 		posts_ctx["current_page_number"] = current_page_number
 		posts_ctx["paginator"] = one_page
 		if current_page_number >= 2 {


### PR DESCRIPTION
Also fix the active page in paginator_navigation

Before the fix, I got errors as below:
2013/03/04 00:03:28 compile.go:589: 3 /posts/ paginator 4
2013/03/04 00:03:28 compile.go:592: page number = 1
2013/03/04 00:03:28 compile.go:592: page number = 2
2013/03/04 00:03:28 compile.go:592: page number = 3
2013/03/04 00:03:28 compile.go:592: page number = 4
2013/03/04 00:03:28 node.go:88: What? 0xf8401cac00
2013/03/04 00:03:28 context.go:228: Not Support kind=func
2013/03/04 00:03:28 context.go:228: Not Support kind=func
2013/03/04 00:03:28 node.go:88: What? 0xf8401cac00
2013/03/04 00:03:28 node.go:88: What? 0xf8401cac40
2013/03/04 00:03:28 context.go:228: Not Support kind=func
2013/03/04 00:03:28 context.go:228: Not Support kind=func
2013/03/04 00:03:28 node.go:88: What? 0xf8401cac40
2013/03/04 00:03:28 node.go:88: What? 0xf8401cac80
2013/03/04 00:03:28 context.go:228: Not Support kind=func
2013/03/04 00:03:28 context.go:228: Not Support kind=func
2013/03/04 00:03:28 node.go:88: What? 0xf8401cac80
2013/03/04 00:03:28 node.go:88: What? 0xf8401cacc0
2013/03/04 00:03:28 context.go:228: Not Support kind=func
2013/03/04 00:03:28 context.go:228: Not Support kind=func
2
