### PR TITLE
增加{:toc}的支持

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -560,6 +560,7 @@ func MakeSummary(post Mapper, lines int, topCtx mustache.Context) string {
 			str = post["_content"].(*DocContent).Main
 		}
 	}
+	str = strings.Replace(str, TOC_MARKUP, "", 1)
 	return MarkdownToHtml(str)
 }
 

--- a/markdown.go
+++ b/markdown.go
@@ -3,11 +3,21 @@ package gor
 import (
 	//"bytes"
 	// "github.com/knieriem/markdown"
-	"github.com/russross/blackfriday"
+	. "github.com/russross/blackfriday"
 	"log"
+	"regexp"
+	"strings"
 )
 
 // 封装Markdown转换为Html的逻辑
+
+const (
+	//http://maruku.rubyforge.org/maruku.html#toc-generation
+	TOC_MARKUP = "{:toc}"
+)
+
+var navRegex = regexp.MustCompile(`(?ismU)<nav>(.*)</nav>`)
+
 func MarkdownToHtml(content string) (str string) {
 	defer func() {
 		e := recover()
@@ -23,6 +33,35 @@ func MarkdownToHtml(content string) (str string) {
 		mdParser.Markdown(bytes.NewBufferString(content), markdown.ToHTML(buf))
 		str = buf.String()
 	*/
-	str = string(blackfriday.MarkdownCommon([]byte(content)))
-	return
+
+	htmlFlags := 0
+
+	if strings.Contains(content, TOC_MARKUP) {
+		htmlFlags |= HTML_TOC
+	}
+
+	htmlFlags |= HTML_USE_XHTML
+	htmlFlags |= HTML_USE_SMARTYPANTS
+	htmlFlags |= HTML_SMARTYPANTS_FRACTIONS
+	htmlFlags |= HTML_SMARTYPANTS_LATEX_DASHES
+	renderer := HtmlRenderer(htmlFlags, "", "")
+
+	// set up the parser
+	extensions := 0
+	extensions |= EXTENSION_NO_INTRA_EMPHASIS
+	extensions |= EXTENSION_TABLES
+	extensions |= EXTENSION_FENCED_CODE
+	extensions |= EXTENSION_AUTOLINK
+	extensions |= EXTENSION_STRIKETHROUGH
+	extensions |= EXTENSION_SPACE_HEADERS
+
+	str = string(Markdown([]byte(content), renderer, extensions))
+
+	found := navRegex.FindIndex([]byte(str))
+	if len(found) > 0 {
+		toc := str[found[0]:found[1]]
+		str = str[found[1]:]
+		str = strings.Replace(str, TOC_MARKUP, toc, -1)
+	}
+	return str
 }


### PR DESCRIPTION
文章如果包含了{:toc}，会被替换成目录。

效果可参考： http://hugozhu.myalert.info/2013/03/09/setup-archliunx-on-raspberry-pi.html#toc_3
