### PR TITLE
Added TOC_TITLE support in markdown

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -32,6 +32,10 @@ func Compile() error {
 	payload_ctx := mustache.MakeContextDir(payload, ".tmp_partials/")
 	themeName := FromCtx(payload_ctx, "site.config.theme").(string)
 
+	if FromCtx(payload_ctx, "site.config.markdown.toc_title") != nil {
+		TOC_TITLE = FromCtx(payload_ctx, "site.config.markdown.toc_title").(string)
+	}
+
 	os.Remove(".tmp_partials")
 	copyDir("partials", ".tmp_partials")
 	copyDir("themes/"+themeName+"/partials", ".tmp_partials")

--- a/markdown.go
+++ b/markdown.go
@@ -16,6 +16,10 @@ const (
 	TOC_MARKUP = "{:toc}"
 )
 
+var (
+	TOC_TITLE = "<h1>Index:</h1>"
+)
+
 var navRegex = regexp.MustCompile(`(?ismU)<nav>(.*)</nav>`)
 
 func MarkdownToHtml(content string) (str string) {
@@ -61,6 +65,7 @@ func MarkdownToHtml(content string) (str string) {
 		found := navRegex.FindIndex([]byte(str))
 		if len(found) > 0 {
 			toc := str[found[0]:found[1]]
+			toc = TOC_TITLE + toc
 			str = str[found[1]:]
 			str = strings.Replace(str, TOC_MARKUP, toc, -1)
 		}


### PR DESCRIPTION
config.xml 增加了markdown相关的配置：如：目录的标题

markdown:
    toc_title: '目录：'

eg: https://github.com/hugozhu/blog/commit/375efd4c78a3161ff495339d302c19321b459330#config.yml
