### PR TITLE
change post default permalink to post filename trim .md

### DIFF
--- a/payload.go
+++ b/payload.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	URL "net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -167,7 +168,6 @@ func BuildPayload(root string) (payload map[string]interface{}, err error) {
 	post_layout_default := cnf_posts.Layout()
 	page_layout_default := cnf_pages.Layout()
 
-	post_permalink_default := cnf_posts.Permalink()
 	page_permalink_default := cnf_pages.Permalink()
 
 	// 为Page和Post补齐layout和permalink
@@ -245,7 +245,7 @@ func BuildPayload(root string) (payload map[string]interface{}, err error) {
 			post["layout"] = post_layout_default
 		}
 		if post.Permalink() == "" {
-			post["permalink"] = post_permalink_default
+			post["permalink"] = strings.TrimSuffix(path.Base(post["id"].(string)), ".md")
 		}
 
 		for _, _tag := range post.Tags() {


### PR DESCRIPTION
默认的永久链接是 catelogs/title。
但我觉得改成 post/filename.md 中的 filename 会更合适一点，如果注意的话起名字的话也不会重复。
一篇文章是 myarticle.md 则文章链接为 myblog.com/article